### PR TITLE
Fixing GA tracking problem on LogIn button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### CHANGE LOG
 
+### v2.4.1
+> Updating Header component to track GA events in LogIn button.
+
 #### v2.4.0
 > This is the first release (of two) with accessibility updates. This update includes:
 > Update to the focus ring.

--- a/dist/components/Header/Header.js
+++ b/dist/components/Header/Header.js
@@ -319,7 +319,8 @@ var Header = function (_React$Component) {
                     refId: 'desktopLogin',
                     isLoggedIn: isLoggedIn,
                     patronName: this.state.patronName,
-                    logOutLink: this.state.logOutUrl
+                    logOutLink: this.state.logOutUrl,
+                    gaAction: gaAction
                   })
                 ),
                 _react2.default.createElement(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "NYPL Header as a React component.",
   "main": "dist/components/Header/Header.js",
   "scripts": {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -233,6 +233,7 @@ class Header extends React.Component {
                     isLoggedIn={isLoggedIn}
                     patronName={this.state.patronName}
                     logOutLink={this.state.logOutUrl}
+                    gaAction={gaAction}
                   />
                 </li>
                 <li>


### PR DESCRIPTION
After some investigation, @ktp242 and I discovered that the line `gaAction={gaAction}` was missing from `MyNyplButton` in the `Header` component. After adding the line, the debug mode was consoling out lines as intended.