### PR TITLE
Account for undefined appEnv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### CHANGE LOG
 
 =======
+### v2.4.16
+> Sets catalogBaseUrl when appEnv is undefined
+
 ### v2.4.15
 > Adds a check for QA in APP_ENV
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is for the header component used in React applications at NYPL.
 
 ### Version
 
-> v2.4.15
+> v2.4.16
 
 ### App Installation
 

--- a/dist/components/SearchBox/SearchBox.js
+++ b/dist/components/SearchBox/SearchBox.js
@@ -226,7 +226,9 @@ var SearchBox = function (_React$Component) {
       var searchOptionValue = this.state.searchOption;
       var encoreBaseUrl = 'https://browse.nypl.org/iii/encore/search/';
       var catalogBaseUrl = void 0;
-      if (appEnv === 'development') {
+      if (!appEnv) {
+        catalogBaseUrl = '//www.nypl.org/search/';
+      } else if (appEnv === 'development') {
         catalogBaseUrl = '//dev-www.nypl.org/search/';
       } else if (appEnv === 'qa') {
         catalogBaseUrl = '//qa-www.nypl.org/search/';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "description": "NYPL Header as a React component.",
   "main": "dist/components/Header/Header.js",
   "scripts": {

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -172,7 +172,9 @@ class SearchBox extends React.Component {
     const searchOptionValue = this.state.searchOption;
     const encoreBaseUrl = 'https://browse.nypl.org/iii/encore/search/';
     let catalogBaseUrl;
-    if (appEnv === 'development') {
+    if (!appEnv) {
+      catalogBaseUrl = '//www.nypl.org/search/';
+    } else if (appEnv === 'development') {
       catalogBaseUrl = '//dev-www.nypl.org/search/';
     } else if (appEnv === 'qa') {
       catalogBaseUrl = '//qa-www.nypl.org/search/';


### PR DESCRIPTION
In Drupal environments, we can't rely upon Webpack to set environment variables.