### PR TITLE
Remove hardcoding and add console logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### CHANGE LOG
 
 =======
+### v2.4.19
+> Remove the hardcoding to test that dist was the solution.
+
 ### v2.4.18
 > Run babel-build so that the dist directory is updated.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is for the header component used in React applications at NYPL.
 
 ### Version
 
-> v2.4.18
+> v2.4.19
 
 ### App Installation
 

--- a/dist/components/SearchBox/SearchBox.js
+++ b/dist/components/SearchBox/SearchBox.js
@@ -226,16 +226,18 @@ var SearchBox = function (_React$Component) {
       var searchOptionValue = this.state.searchOption;
       var encoreBaseUrl = 'https://browse.nypl.org/iii/encore/search/';
       var catalogBaseUrl = void 0;
-      var appEnv = 'production';
-      if (!appEnv) {
+      try {
+        if (appEnv === 'development') {
+          catalogBaseUrl = '//dev-www.nypl.org/search/';
+        } else if (appEnv === 'qa') {
+          catalogBaseUrl = '//qa-www.nypl.org/search/';
+        } else {
+          catalogBaseUrl = '//www.nypl.org/search/';
+        };
+      } catch (err) {
+        // When the header is on old/new Drupal, appEnv will not be set so it will always get caught here.
         catalogBaseUrl = '//www.nypl.org/search/';
-      } else if (appEnv === 'development') {
-        catalogBaseUrl = '//dev-www.nypl.org/search/';
-      } else if (appEnv === 'qa') {
-        catalogBaseUrl = '//qa-www.nypl.org/search/';
-      } else {
-        catalogBaseUrl = '//www.nypl.org/search/';
-      };
+      }
 
       // For GA "Search" Catalog, "Query Sent" Action Event
       // GASearchedRepo indicates which kind of search is sent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "description": "NYPL Header as a React component.",
   "main": "dist/components/Header/Header.js",
   "scripts": {

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -172,16 +172,19 @@ class SearchBox extends React.Component {
     const searchOptionValue = this.state.searchOption;
     const encoreBaseUrl = 'https://browse.nypl.org/iii/encore/search/';
     let catalogBaseUrl;
-    let appEnv = 'production';
-    if (!appEnv) {
+    try {
+      if (appEnv === 'development') {
+        catalogBaseUrl = '//dev-www.nypl.org/search/';
+      } else if (appEnv === 'qa') {
+        catalogBaseUrl = '//qa-www.nypl.org/search/';
+      } else {
+        catalogBaseUrl = '//www.nypl.org/search/';
+      };
+    }
+    catch(err) {
+      // When the header is on old/new Drupal, appEnv will not be set so it will always get caught here.
       catalogBaseUrl = '//www.nypl.org/search/';
-    } else if (appEnv === 'development') {
-      catalogBaseUrl = '//dev-www.nypl.org/search/';
-    } else if (appEnv === 'qa') {
-      catalogBaseUrl = '//qa-www.nypl.org/search/';
-    } else {
-      catalogBaseUrl = '//www.nypl.org/search/';
-    };
+    }
 
     // For GA "Search" Catalog, "Query Sent" Action Event
     // GASearchedRepo indicates which kind of search is sent


### PR DESCRIPTION
@ktp242 when we used these log statements...
<img width="624" alt="screen shot 2018-12-19 at 12 38 55 pm" src="https://user-images.githubusercontent.com/1825103/50237669-7c2a5f80-038b-11e9-8e71-915cebf7a862.png">

we see these log messages when performing a search at https://qa-www.nypl.org/locations/ ...
![log](https://user-images.githubusercontent.com/1825103/50237926-1ee2de00-038c-11e9-8ef7-a4cbbdd629d8.png)

And we are successfully taken to the new search URL: https://www.nypl.org/search/ab?searched_from=header_search&timestamp=1545241467473

So I removed the logging in the final version of the commit in this PR.