### PR TITLE
Add the mechanism to make sure that Header is shown to be logged afte…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### CHANGE LOG
 
 ========
+### v2.5.1
+> Add the mechanism to make sure that Header is shown to be logged out if the log in related cookies from Encore are deleted.
+
 ### v2.5.0
 > Add the mechanism to remove log in related cookies from Encore, so the patron's log in status will be consistent with Encore server.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is for the header component used in React applications at NYPL.
 
 ### Version
 
-> v2.5.0
+> v2.5.1
 
 ### App Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "NYPL Header as a React component.",
   "main": "dist/components/Header/Header.js",
   "scripts": {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -116,6 +116,8 @@ class Header extends React.Component {
     FeatureFlags.store.listen(this.onFeatureFlagsChange.bind(this));
     // Set the log out link to state
     this.setLogOutLink(window.location.href);
+    // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
+    EncoreLogOutTimer.setEncoreLoggedInTimer(window.location, this.state.currentTime);
     // Set nyplIdentityPatron cookie to the state.
     this.setLoginCookie(this.state.loginCookieName);
     // Set feature flag cookies to the state
@@ -123,8 +125,6 @@ class Header extends React.Component {
     utils.checkFeatureFlagActivated(
       featureFlagConfig.featureFlagList, this.state.isFeatureFlagsActivated
     );
-    // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
-    EncoreLogOutTimer.setEncoreLoggedInTimer(window.location, this.state.currentTime);
   }
 
   componentWillUnmount() {

--- a/src/utils/encoreLogOutTimer.js
+++ b/src/utils/encoreLogOutTimer.js
@@ -30,6 +30,12 @@ function EncoreLogOutTimer() {
 
         this.logOutFromEncoreIn(timeTillLogOut, isTest);
       }
+    } else {
+      // Delete cookie "nyplIdentityPatron" to show Header logged out if cookie "PAT_LOGGED_IN"
+      // does not exist
+      if (utils.hasCookie('nyplIdentityPatron')) {
+        utils.deleteCookie('nyplIdentityPatron');
+      }
     }
   };
 

--- a/test/EncoreLogOutTimer.test.js
+++ b/test/EncoreLogOutTimer.test.js
@@ -9,6 +9,7 @@ import utils from './../src/utils/utils';
 import accountConfig from '../src/accountConfig';
 
 describe('EncoreLogOutTimer', () => {
+  let deleteCookieSpy;
   let setCookieSpy;
   let logOutFromEncoreInSpy;
   let hasCookieStub;
@@ -20,12 +21,16 @@ describe('EncoreLogOutTimer', () => {
     before(() => {
       setCookieSpy = sinon.stub(utils, 'setCookie');
       logOutFromEncoreInSpy = sinon.spy(EncoreLogOutTimer, 'logOutFromEncoreIn');
+      deleteCookieSpy = sinon.spy(utils, 'deleteCookie');
       hasCookieStub = sinon.stub(utils, 'hasCookie');
 
       hasCookieStub
         .withArgs('PAT_LOGGED_IN')
         .onCall(0)
-        .returns(false);
+        .returns(false)
+        .withArgs('nyplIdentityPatron')
+        .onCall(0)
+        .returns(true);
 
       // Set the test flag, the third parameter, to true, so Mocha won't wait the timer to end for
       // 30 mins
@@ -34,13 +39,16 @@ describe('EncoreLogOutTimer', () => {
 
     after(() => {
       setCookieSpy.restore();
+      deleteCookieSpy.restore();
       logOutFromEncoreInSpy.restore();
       utils.hasCookie.restore();
     });
 
-    it('should do nothing.', () => {
+    it('should check if cookie "nyplIdentityPatron" exists and delete it if it does.', () => {
       expect(setCookieSpy.callCount).to.equal(0);
       expect(logOutFromEncoreInSpy.callCount).to.equal(0);
+      expect(deleteCookieSpy.callCount).to.equal(1);
+      expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(true);
     });
   });
 

--- a/test/Header.test.js
+++ b/test/Header.test.js
@@ -223,8 +223,8 @@ describe('Header', () => {
             .withArgs('nyplIdentityPatron')
             .returns(true);
 
-          // The stub here is to make sure cookie 'nyplIdentityPatron' is not deleted because
-          // cookie 'PAT_LOGGED_IN' does not exist
+          // Set `hasCookie` to say that `PAT_LOGGED_IN` exists
+          // so that `nyplIdentityPatron` does not get deleted
           hasCookie = sinon.stub(utils, 'hasCookie')
             .withArgs('PAT_LOGGED_IN')
             .onCall(0)

--- a/test/Header.test.js
+++ b/test/Header.test.js
@@ -214,6 +214,7 @@ describe('Header', () => {
         // functions in utils.js
         let deleteNyplIdentityPatronCookie;
         let hasCookie;
+        let getCookie;
 
         before(() => {
           refreshAccessToken = sinon.spy(utils, 'refreshAccessToken');
@@ -228,6 +229,12 @@ describe('Header', () => {
             .withArgs('PAT_LOGGED_IN')
             .onCall(0)
             .returns(true);
+
+          getCookie = sinon.stub(utils, 'getCookie')
+            .withArgs('ENCORE_LAST_VISITED')
+            // Set a mock last visit time for Encore timer
+            // So cookie "nyplIdentityPatron" will be kept until we test it's access token
+            .returns(Date.now() - 1795000);
 
           mock
             .onGet(mockPatronApiEndpoint)
@@ -245,6 +252,7 @@ describe('Header', () => {
           refreshAccessToken.restore();
           utils.deleteCookie.restore();
           utils.hasCookie.restore();
+          utils.getCookie.restore();
         });
 
         it('should call the cookie refresh API endpoint', (done) => {
@@ -262,7 +270,7 @@ describe('Header', () => {
           (done) => {
             patronApiCall(component, '/refreshError', deleteNyplIdentityPatronCookie);
             setTimeout(() => {
-              expect(deleteNyplIdentityPatronCookie.calledTwice).to.equal(true);
+              expect(deleteNyplIdentityPatronCookie.calledOnce).to.equal(true);
               done();
             }, 1500);
           }


### PR DESCRIPTION
This PR adds the logic to delete cookie "nyplIdentityPatron" if the cookie "PAT_LOGGED_IN" does not exist. The reason to keep Header's log in status align with what Encore indicates and what the last updates we added to delete "PAT_LOGGED_IN" to simulate Encore's behavior when the user is logged out.

Basically, it is an approach to try to align the log in status between Header and Encore better.

The main code changes are on `src/utils/encoreLogOutTimer.js` and also, since we are working with "nyplIdentityPatron", the order after componentDidMount also is changed. See `src/components/Header/Header.js`. So it will delete "nyplIdentityPatron" first if no "PAT_LOGGED_IN" before proceeding to use "nyplIdentityPatron" to get the patron's data.

Also the related tests for these new updates.
