### PR TITLE
Log out with loading iframe

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,63 @@
 {
-  "extends": "airbnb"
+  "extends": [
+    "airbnb"
+  ],
+  "rules": {
+    "function-paren-newline": ["error", "consistent"],
+    "jsx-a11y/label-has-associated-control": [ "error", {
+    "required": {
+        "some": [ "nesting", "id"  ]
+      }
+    }],
+    "jsx-a11y/label-has-for": [ "error", {
+      "required": {
+        "some": [ "nesting", "id"  ]
+      }
+    }],
+    "prefer-destructuring": ["error", {
+      "VariableDeclarator": {
+        "array": true,
+        "object": true
+      },
+      "AssignmentExpression": {
+        "array": false,
+        "object": false
+      }
+    }, {
+      "enforceForRenamedProperties": false
+    }],
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error"
+  },
+  "overrides": [
+    {
+      "files": ["*.test.js"],
+      "rules": {
+        "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+      }
+    },
+    {
+      "files": ["src/app/actions/Actions.js"],
+      "rules": {
+        "class-methods-use-this": [1]
+      }
+    }
+  ],
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true,
+      "modules": true,
+      "experimentalObjectRestSpread": true
+    }
+  },
+  "plugins": [
+    "react"
+  ],
+  "env": {
+    "es6": true,
+    "mocha": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ========
 ### v2.5.3
 > Add the method to completely log out the users by loading the log out endpoint with an invisible iframe.
+> Update the eslint rules and the scripts in package.json to run lint.
 
 ### v2.5.2
 > Add the mechanism to delete the cookie that holds the last visit time for Encore if the user is not logged in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### CHANGE LOG
 
 ========
+### v2.5.3
+> Add the method to completely log out the users by loading the log out endpoint with an invisible iframe.
+
 ### v2.5.2
 > Add the mechanism to delete the cookie that holds the last visit time for Encore if the user is not logged in.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is for the header component used in React applications at NYPL.
 
 ### Version
 
-> v2.5.2
+> v2.5.3
 
 ### App Installation
 

--- a/dist/accountConfig.js
+++ b/dist/accountConfig.js
@@ -4,6 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 var accountConfig = {
+  // the duration of time is in milliseconds
   patLoggedInCookieExpiredTime: 1800000
 };
 

--- a/dist/components/Header/Header.js
+++ b/dist/components/Header/Header.js
@@ -166,7 +166,9 @@ var Header = function (_React$Component) {
         patron = _this$props.patron,
         navData = _this$props.navData,
         _this$props$currentTi = _this$props.currentTime,
-        currentTime = _this$props$currentTi === undefined ? Date.now() || undefined : _this$props$currentTi;
+        currentTime = _this$props$currentTi === undefined ? Date.now() || undefined : _this$props$currentTi,
+        _this$props$isTest = _this$props.isTest,
+        isTest = _this$props$isTest === undefined ? false : _this$props$isTest;
 
 
     var patronNameObject = !(0, _underscore.isEmpty)(patron) && patron.names && patron.names.length ? _utils2.default.modelPatronName(patron.names[0]) : {};
@@ -180,7 +182,8 @@ var Header = function (_React$Component) {
       patronDataReceived: patron.loggedIn || false,
       isFeatureFlagsActivated: {},
       logOutUrl: '',
-      currentTime: currentTime
+      currentTime: currentTime,
+      isTest: isTest
     }, { featureFlagsStore: _dgxFeatureFlags2.default.store.getState() });
     return _this;
   }
@@ -193,7 +196,7 @@ var Header = function (_React$Component) {
       // Set the log out link to state
       this.setLogOutLink(window.location.href);
       // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
-      _encoreLogOutTimer2.default.setEncoreLoggedInTimer(window.location.host, this.state.currentTime);
+      _encoreLogOutTimer2.default.setEncoreLoggedInTimer(window.location.host, this.state.currentTime, this.state.isTest);
       // Set nyplIdentityPatron cookie to the state.
       this.setLoginCookie(this.state.loginCookieName);
       // Set feature flag cookies to the state
@@ -421,6 +424,7 @@ Header.propTypes = {
   navData: _propTypes2.default.arrayOf(_propTypes2.default.object).isRequired,
   skipNav: _propTypes2.default.shape(_dgxSkipNavigationLink2.default.propTypes),
   currentTime: _propTypes2.default.number,
+  isTest: _propTypes2.default.bool,
   patron: _propTypes2.default.shape({
     names: _propTypes2.default.arrayOf(_propTypes2.default.string),
     loggedIn: _propTypes2.default.bool

--- a/dist/components/Header/Header.js
+++ b/dist/components/Header/Header.js
@@ -193,7 +193,7 @@ var Header = function (_React$Component) {
       // Set the log out link to state
       this.setLogOutLink(window.location.href);
       // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
-      _encoreLogOutTimer2.default.setEncoreLoggedInTimer(window.location, this.state.currentTime);
+      _encoreLogOutTimer2.default.setEncoreLoggedInTimer(window.location.host, this.state.currentTime);
       // Set nyplIdentityPatron cookie to the state.
       this.setLoginCookie(this.state.loginCookieName);
       // Set feature flag cookies to the state

--- a/dist/components/Header/Header.js
+++ b/dist/components/Header/Header.js
@@ -192,13 +192,13 @@ var Header = function (_React$Component) {
       _dgxFeatureFlags2.default.store.listen(this.onFeatureFlagsChange.bind(this));
       // Set the log out link to state
       this.setLogOutLink(window.location.href);
+      // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
+      _encoreLogOutTimer2.default.setEncoreLoggedInTimer(window.location, this.state.currentTime);
       // Set nyplIdentityPatron cookie to the state.
       this.setLoginCookie(this.state.loginCookieName);
       // Set feature flag cookies to the state
       // We don't have any feature flags set in the config list at this moment though
       _utils2.default.checkFeatureFlagActivated(_featureFlagConfig2.default.featureFlagList, this.state.isFeatureFlagsActivated);
-      // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
-      _encoreLogOutTimer2.default.setEncoreLoggedInTimer(window.location, this.state.currentTime);
     }
   }, {
     key: 'componentWillUnmount',

--- a/dist/styles/main.scss
+++ b/dist/styles/main.scss
@@ -168,6 +168,10 @@
   @import 'components/_fundraisingBanner';
 }
 
+#logoutIframe {
+  display: none;
+}
+
 /* CSS for Screen Reader Texts */
 // Taken from H5BP
 .visuallyHidden {

--- a/dist/utils/encoreLogOutTimer.js
+++ b/dist/utils/encoreLogOutTimer.js
@@ -45,6 +45,20 @@ function EncoreLogOutTimer() {
 
         _this.logOutFromEncoreIn(timeTillLogOut, isTest);
       }
+    } else {
+      // Delete cookie "nyplIdentityPatron" to show Header logged out if cookie "PAT_LOGGED_IN"
+      // does not exist
+      if (_utils2.default.hasCookie('nyplIdentityPatron')) {
+        _utils2.default.deleteCookie('nyplIdentityPatron');
+      }
+
+      // Delete cookie "ENCORE_LAST_VISITED" which holds the last time the user visited Encore
+      // if the cookie "PAT_LOGGED_IN" does not exist
+      if (_utils2.default.hasCookie('ENCORE_LAST_VISITED')) {
+        _utils2.default.deleteCookie('ENCORE_LAST_VISITED');
+      }
+
+      _this.loadLogoutIframe();
     }
   };
 
@@ -66,7 +80,30 @@ function EncoreLogOutTimer() {
       _utils2.default.deleteCookie('PAT_LOGGED_IN');
       _utils2.default.deleteCookie('ENCORE_LAST_VISITED');
       _utils2.default.deleteCookie('nyplIdentityPatron');
+      _this.loadLogoutIframe();
     }, timeTillLogOut);
+  };
+
+  /**
+   * loadLogoutIframe()
+   * The function that loads a temporary iframe with the log out endpoint
+   * to completely log out the user from Encore. It then deletes the iframe right away.
+   * The reason to use this way to load the endpoint is to bypass the CORS loading from the client
+   * since III does not want to provide us a real log out API URI.
+   */
+  this.loadLogoutIframe = function () {
+    var logoutIframe = document.createElement('iframe');
+    var body = document.getElementsByTagName('body')[0];
+
+    logoutIframe.setAttribute(
+    // The endpoint is the URL for logging out from Encore
+    'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def');
+    // Assigns the ID for CSS ussage
+    logoutIframe.setAttribute('id', 'logoutIframe');
+    body.appendChild(logoutIframe);
+    setTimeout(function () {
+      body.removeChild(logoutIframe);
+    }, 100);
   };
 }
 

--- a/dist/utils/encoreLogOutTimer.js
+++ b/dist/utils/encoreLogOutTimer.js
@@ -4,7 +4,9 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _accountConfig = require('./../accountConfig.js');
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+var _accountConfig = require('../accountConfig');
 
 var _accountConfig2 = _interopRequireDefault(_accountConfig);
 
@@ -32,20 +34,15 @@ function EncoreLogOutTimer() {
     var isTest = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
 
     var encoreLogInExpireDuration = _accountConfig2.default.patLoggedInCookieExpiredTime;
+    var isOnEncore = currentLocation === 'browse.nypl.org';
+    var isLoggedIn = _utils2.default.hasCookie('PAT_LOGGED_IN');
 
-    // See if the user has logged in Encore
-    if (_utils2.default.hasCookie('PAT_LOGGED_IN')) {
-      // Then check if the user is visiting a new Encore page
-      if (currentLocation === 'browse.nypl.org') {
+    if (!isLoggedIn) {
+      // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
+      if (isOnEncore) {
         _utils2.default.setCookie('ENCORE_LAST_VISITED', currentTime);
-        _this.logOutFromEncoreIn(encoreLogInExpireDuration, isTest);
-      } else {
-        var lastVisitedEncoreTime = _utils2.default.getCookie('ENCORE_LAST_VISITED');
-        var timeTillLogOut = lastVisitedEncoreTime ? encoreLogInExpireDuration - (currentTime - lastVisitedEncoreTime) : undefined;
-
-        _this.logOutFromEncoreIn(timeTillLogOut, isTest);
       }
-    } else {
+
       // Delete cookie "nyplIdentityPatron" to show Header logged out if cookie "PAT_LOGGED_IN"
       // does not exist
       if (_utils2.default.hasCookie('nyplIdentityPatron')) {
@@ -58,7 +55,17 @@ function EncoreLogOutTimer() {
         _utils2.default.deleteCookie('ENCORE_LAST_VISITED');
       }
 
+      // Completely log out the user
       _this.loadLogoutIframe();
+    } else if (isOnEncore) {
+      // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
+      _utils2.default.setCookie('ENCORE_LAST_VISITED', currentTime);
+      _this.logOutFromEncoreIn(encoreLogInExpireDuration, isTest);
+    } else {
+      var lastVisitedEncoreTime = _utils2.default.getCookie('ENCORE_LAST_VISITED');
+      var timeTillLogOut = lastVisitedEncoreTime ? encoreLogInExpireDuration - (currentTime - lastVisitedEncoreTime) : undefined;
+
+      _this.logOutFromEncoreIn(timeTillLogOut, isTest);
     }
   };
 
@@ -93,7 +100,10 @@ function EncoreLogOutTimer() {
    */
   this.loadLogoutIframe = function () {
     var logoutIframe = document.createElement('iframe');
-    var body = document.getElementsByTagName('body')[0];
+
+    var _document$getElements = document.getElementsByTagName('body'),
+        _document$getElements2 = _slicedToArray(_document$getElements, 1),
+        body = _document$getElements2[0];
 
     logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore

--- a/dist/utils/encoreLogOutTimer.js
+++ b/dist/utils/encoreLogOutTimer.js
@@ -44,17 +44,25 @@ function EncoreLogOutTimer() {
         _utils2.default.deleteCookie('nyplIdentityPatron');
       }
 
+      // Delete cookie "ENCORE_LAST_VISITED" which holds the last time the user visited Encore
+      // if the cookie "PAT_LOGGED_IN" does not exist
+      if (_utils2.default.hasCookie('ENCORE_LAST_VISITED')) {
+        _utils2.default.deleteCookie('ENCORE_LAST_VISITED');
+      }
+
       // Completely log out the user
       _this.loadLogoutIframe();
-    } else if (isOnEncore) {
-      // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
-      _utils2.default.setCookie('ENCORE_LAST_VISITED', currentTime);
-      _this.logOutFromEncoreIn(encoreLogInExpireDuration, isTest);
     } else {
-      var lastVisitedEncoreTime = _utils2.default.getCookie('ENCORE_LAST_VISITED');
-      var timeTillLogOut = lastVisitedEncoreTime ? encoreLogInExpireDuration - (currentTime - lastVisitedEncoreTime) : undefined;
+      if (isOnEncore) {
+        // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
+        _utils2.default.setCookie('ENCORE_LAST_VISITED', currentTime);
+        _this.logOutFromEncoreIn(encoreLogInExpireDuration, isTest);
+      } else {
+        var lastVisitedEncoreTime = _utils2.default.getCookie('ENCORE_LAST_VISITED');
+        var timeTillLogOut = lastVisitedEncoreTime ? encoreLogInExpireDuration - (currentTime - lastVisitedEncoreTime) : undefined;
 
-      _this.logOutFromEncoreIn(timeTillLogOut, isTest);
+        _this.logOutFromEncoreIn(timeTillLogOut, isTest);
+      }
     }
   };
 

--- a/dist/utils/encoreLogOutTimer.js
+++ b/dist/utils/encoreLogOutTimer.js
@@ -20,39 +20,28 @@ function EncoreLogOutTimer() {
   var _this = this;
 
   /**
-   * setEncoreLoggedInTimer(currentLocation, currentTime, isTest)
+   * setEncoreLoggedInTimer(currentLocationHost, currentTime, isTest)
    * This method is to set the timer to delete ‘PAT_LOGGED_IN’ cookie after its expiration time.
    * This is to keep the logged in status consistent with Encore server,
    * so the patrons don’t have to log in when they are using non-account-required operations,
    * such as searching items.
    * The default expiration time is 30 mins.
-   * @param {object} - The window.location object
+   * @param {object} - The current location's host
    * @param {number} - The milliseconds elapsed since January 1, 1970 from Date.now()
    * @param {boolean} - The flag to determine if the function is run for tests
    */
-  this.setEncoreLoggedInTimer = function (currentLocation, currentTime) {
+  this.setEncoreLoggedInTimer = function (currentLocationHost, currentTime) {
     var isTest = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
 
     var encoreLogInExpireDuration = _accountConfig2.default.patLoggedInCookieExpiredTime;
-    var isOnEncore = currentLocation === 'browse.nypl.org';
+    var isOnEncore = currentLocationHost === 'browse.nypl.org';
     var isLoggedIn = _utils2.default.hasCookie('PAT_LOGGED_IN');
 
     if (!isLoggedIn) {
-      // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
-      if (isOnEncore) {
-        _utils2.default.setCookie('ENCORE_LAST_VISITED', currentTime);
-      }
-
       // Delete cookie "nyplIdentityPatron" to show Header logged out if cookie "PAT_LOGGED_IN"
       // does not exist
       if (_utils2.default.hasCookie('nyplIdentityPatron')) {
         _utils2.default.deleteCookie('nyplIdentityPatron');
-      }
-
-      // Delete cookie "ENCORE_LAST_VISITED" which holds the last time the user visited Encore
-      // if the cookie "PAT_LOGGED_IN" does not exist
-      if (_utils2.default.hasCookie('ENCORE_LAST_VISITED')) {
-        _utils2.default.deleteCookie('ENCORE_LAST_VISITED');
       }
 
       // Completely log out the user

--- a/dist/utils/encoreLogOutTimer.js
+++ b/dist/utils/encoreLogOutTimer.js
@@ -110,7 +110,7 @@ function EncoreLogOutTimer() {
     body.appendChild(logoutIframe);
     setTimeout(function () {
       body.removeChild(logoutIframe);
-    }, 100);
+    }, 10000);
   };
 }
 

--- a/dist/utils/encoreLogOutTimer.js
+++ b/dist/utils/encoreLogOutTimer.js
@@ -51,7 +51,7 @@ function EncoreLogOutTimer() {
       }
 
       // Completely log out the user
-      _this.loadLogoutIframe();
+      _this.loadLogoutIframe(isTest);
     } else {
       if (isOnEncore) {
         // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
@@ -76,31 +76,34 @@ function EncoreLogOutTimer() {
     var timeTillLogOut = time > 0 ? time : 0;
 
     // Only for testing. If the function is run for tests, set the timeout no longer than 2 seconds
-    if (isTest && timeTillLogOut > 2000) {
-      timeTillLogOut = 2000;
+    if (isTest && timeTillLogOut > 8000) {
+      timeTillLogOut = 8000;
     }
 
     setTimeout(function () {
       _utils2.default.deleteCookie('PAT_LOGGED_IN');
       _utils2.default.deleteCookie('ENCORE_LAST_VISITED');
       _utils2.default.deleteCookie('nyplIdentityPatron');
-      _this.loadLogoutIframe();
+      _this.loadLogoutIframe(isTest);
     }, timeTillLogOut);
   };
 
   /**
-   * loadLogoutIframe()
+   * loadLogoutIframe(isTest)
    * The function that loads a temporary iframe with the log out endpoint
    * to completely log out the user from Encore. It then deletes the iframe right away.
    * The reason to use this way to load the endpoint is to bypass the CORS loading from the client
    * since III does not want to provide us a real log out API URI.
+   * * @param {isTest} - If running this method for testing, delete the iframe right away
    */
-  this.loadLogoutIframe = function () {
+  this.loadLogoutIframe = function (isTest) {
     var logoutIframe = document.createElement('iframe');
 
     var _document$getElements = document.getElementsByTagName('body'),
         _document$getElements2 = _slicedToArray(_document$getElements, 1),
         body = _document$getElements2[0];
+
+    var iframeExistingTime = isTest ? 100 : 100000;
 
     logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore
@@ -110,7 +113,7 @@ function EncoreLogOutTimer() {
     body.appendChild(logoutIframe);
     setTimeout(function () {
       body.removeChild(logoutIframe);
-    }, 10000);
+    }, iframeExistingTime);
   };
 }
 

--- a/dist/utils/encoreLogOutTimer.js
+++ b/dist/utils/encoreLogOutTimer.js
@@ -103,7 +103,7 @@ function EncoreLogOutTimer() {
         _document$getElements2 = _slicedToArray(_document$getElements, 1),
         body = _document$getElements2[0];
 
-    var iframeExistingTime = isTest ? 100 : 100000;
+    var iframeExistingTime = isTest ? 100 : 10000;
 
     logoutIframe.setAttribute(
     // The endpoint is the URL for logging out from Encore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,216 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.4.10",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@nypl/design-toolkit": {
       "version": "0.1.36",
       "resolved": "https://registry.npmjs.org/@nypl/design-toolkit/-/design-toolkit-0.1.36.tgz",
@@ -110,6 +317,12 @@
         "acorn": "^2.1.0"
       }
     },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -164,6 +377,12 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -213,6 +432,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -244,6 +473,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
       "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
       "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
     },
     "array-union": {
       "version": "1.0.2",
@@ -311,6 +550,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
@@ -391,6 +642,15 @@
         "deep-equal": "^1.0.1"
       }
     },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
     "babel-cli": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
@@ -465,6 +725,20 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      }
+    },
+    "babel-eslint": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.0.tgz",
+      "integrity": "sha512-GDQOtoj8CFtEe1HlbuEb6rwdbxRr4Y5DWyddivdsriEj6ulDda+fS43Zfe/Ku0tuMNnxC9JK1bmIovsLq5+hUA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "babel-generator": {
@@ -1467,6 +1741,12 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -1554,6 +1834,12 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "cheerio": {
       "version": "0.22.0",
@@ -1643,6 +1929,21 @@
       "requires": {
         "rimraf": "^2.6.1"
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "3.2.0",
@@ -1804,6 +2105,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "content-disposition": {
@@ -2104,6 +2411,12 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2257,7 +2570,7 @@
       "from": "git+https://git@bitbucket.org/NYPL/dgx-feature-flags.git#master",
       "requires": {
         "alt-utils": "1.0.0",
-        "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#b3915c1cf33ed7f70446750dcbc6fcf98faaed37",
+        "dgx-alt-center": "git+https://bitbucket.org/NYPL/dgx-alt-center.git#master",
         "immutable": "3.7.6"
       }
     },
@@ -2313,6 +2626,15 @@
       "dev": true,
       "requires": {
         "buffer-indexof": "^1.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "dom-serializer": {
@@ -2408,6 +2730,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -2538,11 +2866,525 @@
         }
       }
     },
+    "eslint": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz",
+      "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^13.1.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
+      "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
+      "dev": true,
+      "requires": {
+        "eslint-restricted-globals": "^0.1.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      }
+    },
+    "eslint-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.3.0.tgz",
+      "integrity": "sha1-AuKI1hQ0EXwmAAdYyHaMm/kiSnY=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.7",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.1.tgz",
+      "integrity": "sha512-lzD9uvRvW4MsHzIOMJEDSb5MOV9LzgxRPBaovvOhJqzgxRHYfGy9QOrMuwHIh5ehKFJ7Z3DcrcGKDQ0IbP0EdQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+      "dev": true,
+      "requires": {
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1"
+      },
+      "dependencies": {
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.12.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
+      "integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.6.2",
+        "resolve": "^1.9.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -2668,6 +3510,28 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -2784,6 +3648,24 @@
         }
       }
     },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -2847,6 +3729,48 @@
           }
         }
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
     },
     "flatten": {
       "version": "1.0.2",
@@ -2990,7 +3914,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -3049,7 +3974,8 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -3066,6 +3992,7 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -3075,6 +4002,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -3084,6 +4012,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -3093,7 +4022,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
           "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -3113,13 +4043,15 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -3128,25 +4060,29 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -3191,7 +4127,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -3228,7 +4165,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
           "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -3253,13 +4191,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -3320,6 +4260,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -3333,7 +4274,8 @@
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -3365,6 +4307,7 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -3376,7 +4319,8 @@
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -3395,6 +4339,7 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -3404,7 +4349,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -3418,6 +4364,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3433,7 +4380,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -3516,13 +4464,15 @@
           "version": "1.27.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
           "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -3532,6 +4482,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3540,13 +4491,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3606,7 +4559,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -3627,6 +4581,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3660,7 +4615,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -3673,7 +4629,8 @@
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -3716,6 +4673,7 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -3762,6 +4720,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -3770,7 +4729,8 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
           "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -3798,6 +4758,7 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -3834,6 +4795,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3845,6 +4807,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -3861,6 +4824,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3877,6 +4841,7 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -3938,7 +4903,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -3971,7 +4937,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4002,6 +4969,12 @@
         "function-bind": "^1.1.1",
         "is-callable": "^1.1.3"
       }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -4478,10 +5451,32 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
     "immutable": {
       "version": "3.7.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
@@ -4521,6 +5516,120 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "internal-ip": {
       "version": "1.2.0",
@@ -4909,6 +6018,12 @@
         "jsonify": "~0.0.0"
       }
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -4941,6 +6056,15 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3"
       }
     },
     "just-extend": {
@@ -5010,6 +6134,16 @@
         "emojis-list": "^2.0.0",
         "json5": "^0.5.0",
         "object-assign": "^4.0.1"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -5313,6 +6447,12 @@
         "mime-db": "~1.30.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -5436,6 +6576,12 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
@@ -5447,10 +6593,22 @@
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "nise": {
@@ -5709,6 +6867,7 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6365,7 +7524,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.0.1",
@@ -7059,6 +8219,77 @@
         "has": "^1.0.1"
       }
     },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+          "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-keys": "^1.0.12"
+          },
+          "dependencies": {
+            "has": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+              "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            }
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+          "dev": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -7108,6 +8339,15 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
       }
     },
     "opn": {
@@ -7199,10 +8439,34 @@
         "object-assign": "^4.1.0"
       }
     },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "pako": {
@@ -7210,6 +8474,15 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
       "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
     },
     "parse-asn1": {
       "version": "5.1.0",
@@ -7262,6 +8535,12 @@
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -7271,6 +8550,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -8037,6 +9328,12 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -8397,6 +9694,12 @@
         }
       }
     },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
+    },
     "react-tappable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-tappable/-/react-tappable-1.0.0.tgz",
@@ -8524,6 +9827,12 @@
         "is-equal-shallow": "^0.1.3"
       }
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
@@ -8627,6 +9936,31 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -8669,10 +10003,34 @@
         "inherits": "^2.0.1"
       }
     },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "samsam": {
       "version": "1.3.0",
@@ -8852,6 +10210,21 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -8888,6 +10261,34 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "sockjs": {
       "version": "0.3.18",
@@ -9120,6 +10521,12 @@
         "get-stdin": "^4.0.1"
       }
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "style-loader": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
@@ -9174,6 +10581,82 @@
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.2.tgz",
       "integrity": "sha512-77oqsKEPrxIwgRcXUwipkj9W5ItO97L6eUT1Ar7vh+El16Zm4M6V+YU1cbipHEa6q0Yjw8O3Hoh8oRgatV5s7A=="
     },
+    "table": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "tapable": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
@@ -9209,6 +10692,18 @@
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "thunky": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
@@ -9228,6 +10723,15 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -9270,6 +10774,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "tty-browserify": {
@@ -9399,6 +10909,23 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
     },
     "url": {
       "version": "0.11.0",
@@ -9851,6 +11378,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xml-name-validator": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test-with-coverage": "IS_TEST_ENV=true ./node_modules/.bin/nyc ./node_modules/.bin/mocha test/helpers/browser.js test/*.test.js",
     "coverage": "BABEL_ENV=test node_modules/.bin/nyc --require mocha npm test",
     "coverage-report": "BABEL_ENV=test node_modules/.bin/nyc report --reporter=lcov",
-    "coverage-report-html": "BABEL_ENV=test ./node_modules/.bin/nyc report --reporter=html && open -a 'Google Chrome' ./coverage/index.html"
+    "coverage-report-html": "BABEL_ENV=test ./node_modules/.bin/nyc report --reporter=html && open -a 'Google Chrome' ./coverage/index.html",
+    "lint": "eslint ./",
+    "lint-single-file": "eslint"
   },
   "author": "NYPL Digital Experience",
   "contributors": [
@@ -67,6 +69,7 @@
     "axios-mock-adapter": "1.7.1",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.3",
+    "babel-eslint": "10.0.0",
     "babel-loader": "6.4.1",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-istanbul": "3.0.0",
@@ -78,6 +81,12 @@
     "create-react-class": "15.5.3",
     "css-loader": "0.28.7",
     "enzyme": "2.9.1",
+    "eslint": "^5.9.0",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-loader": "1.3.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-react": "^7.11.1",
     "extract-text-webpack-plugin": "2.1.2",
     "jsdom": "9.8.3",
     "mocha": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "NYPL Header as a React component.",
   "main": "dist/components/Header/Header.js",
   "scripts": {

--- a/src/accountConfig.js
+++ b/src/accountConfig.js
@@ -1,4 +1,5 @@
 const accountConfig = {
+  // the duration of time is in milliseconds
   patLoggedInCookieExpiredTime: 1800000,
 };
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -90,6 +90,7 @@ class Header extends React.Component {
       patron,
       navData,
       currentTime = Date.now() || undefined,
+      isTest = false,
     } = this.props;
 
     const patronNameObject = !_isEmpty(patron) && patron.names && patron.names.length ?
@@ -106,6 +107,7 @@ class Header extends React.Component {
         isFeatureFlagsActivated: {},
         logOutUrl: '',
         currentTime,
+        isTest,
       },
       { featureFlagsStore: FeatureFlags.store.getState() },
     );
@@ -117,7 +119,11 @@ class Header extends React.Component {
     // Set the log out link to state
     this.setLogOutLink(window.location.href);
     // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
-    EncoreLogOutTimer.setEncoreLoggedInTimer(window.location.host, this.state.currentTime);
+    EncoreLogOutTimer.setEncoreLoggedInTimer(
+      window.location.host,
+      this.state.currentTime,
+      this.state.isTest
+    );
     // Set nyplIdentityPatron cookie to the state.
     this.setLoginCookie(this.state.loginCookieName);
     // Set feature flag cookies to the state
@@ -327,6 +333,7 @@ Header.propTypes = {
   navData: PropTypes.arrayOf(PropTypes.object).isRequired,
   skipNav: PropTypes.shape(SkipNavigation.propTypes),
   currentTime: PropTypes.number,
+  isTest: PropTypes.bool,
   patron: PropTypes.shape({
     names: PropTypes.arrayOf(PropTypes.string),
     loggedIn: PropTypes.bool,

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -117,7 +117,7 @@ class Header extends React.Component {
     // Set the log out link to state
     this.setLogOutLink(window.location.href);
     // Check if the cookie "PAT_LOGGED_IN" exists and then set the timer for deleting it
-    EncoreLogOutTimer.setEncoreLoggedInTimer(window.location, this.state.currentTime);
+    EncoreLogOutTimer.setEncoreLoggedInTimer(window.location.host, this.state.currentTime);
     // Set nyplIdentityPatron cookie to the state.
     this.setLoginCookie(this.state.loginCookieName);
     // Set feature flag cookies to the state

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -168,6 +168,10 @@
   @import 'components/_fundraisingBanner';
 }
 
+#logoutIframe {
+  display: none;
+}
+
 /* CSS for Screen Reader Texts */
 // Taken from H5BP
 .visuallyHidden {

--- a/src/utils/encoreLogOutTimer.js
+++ b/src/utils/encoreLogOutTimer.js
@@ -32,7 +32,7 @@ function EncoreLogOutTimer() {
       }
 
       // Completely log out the user
-      this.loadLogoutIframe();
+      this.loadLogoutIframe(isTest);
     } else {
       if (isOnEncore) {
         // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
@@ -59,28 +59,30 @@ function EncoreLogOutTimer() {
     let timeTillLogOut = (time > 0) ? time : 0;
 
     // Only for testing. If the function is run for tests, set the timeout no longer than 2 seconds
-    if (isTest && timeTillLogOut > 2000) {
-      timeTillLogOut = 2000;
+    if (isTest && timeTillLogOut > 8000) {
+      timeTillLogOut = 8000;
     }
 
     setTimeout(() => {
       utils.deleteCookie('PAT_LOGGED_IN');
       utils.deleteCookie('ENCORE_LAST_VISITED');
       utils.deleteCookie('nyplIdentityPatron');
-      this.loadLogoutIframe();
+      this.loadLogoutIframe(isTest);
     }, timeTillLogOut);
   };
 
   /**
-   * loadLogoutIframe()
+   * loadLogoutIframe(isTest)
    * The function that loads a temporary iframe with the log out endpoint
    * to completely log out the user from Encore. It then deletes the iframe right away.
    * The reason to use this way to load the endpoint is to bypass the CORS loading from the client
    * since III does not want to provide us a real log out API URI.
+   * * @param {isTest} - If running this method for testing, delete the iframe right away
    */
-  this.loadLogoutIframe = () => {
+  this.loadLogoutIframe = (isTest) => {
     const logoutIframe = document.createElement('iframe');
     const [body] = document.getElementsByTagName('body');
+    const iframeExistingTime = isTest ? 100 : 100000;
 
     logoutIframe.setAttribute(
       // The endpoint is the URL for logging out from Encore
@@ -89,7 +91,7 @@ function EncoreLogOutTimer() {
     // Assigns the ID for CSS ussage
     logoutIframe.setAttribute('id', 'logoutIframe');
     body.appendChild(logoutIframe);
-    setTimeout(() => { body.removeChild(logoutIframe); }, 10000);
+    setTimeout(() => { body.removeChild(logoutIframe); }, iframeExistingTime);
   };
 }
 

--- a/src/utils/encoreLogOutTimer.js
+++ b/src/utils/encoreLogOutTimer.js
@@ -25,19 +25,27 @@ function EncoreLogOutTimer() {
         utils.deleteCookie('nyplIdentityPatron');
       }
 
+      // Delete cookie "ENCORE_LAST_VISITED" which holds the last time the user visited Encore
+      // if the cookie "PAT_LOGGED_IN" does not exist
+      if (utils.hasCookie('ENCORE_LAST_VISITED')) {
+        utils.deleteCookie('ENCORE_LAST_VISITED');
+      }
+
       // Completely log out the user
       this.loadLogoutIframe();
-    } else if (isOnEncore) {
-      // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
-      utils.setCookie('ENCORE_LAST_VISITED', currentTime);
-      this.logOutFromEncoreIn(encoreLogInExpireDuration, isTest);
     } else {
-      const lastVisitedEncoreTime = utils.getCookie('ENCORE_LAST_VISITED');
-      const timeTillLogOut = lastVisitedEncoreTime
-        ? encoreLogInExpireDuration - (currentTime - lastVisitedEncoreTime)
-        : undefined;
+      if (isOnEncore) {
+        // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
+        utils.setCookie('ENCORE_LAST_VISITED', currentTime);
+        this.logOutFromEncoreIn(encoreLogInExpireDuration, isTest);
+      } else {
+        const lastVisitedEncoreTime = utils.getCookie('ENCORE_LAST_VISITED');
+        const timeTillLogOut = lastVisitedEncoreTime
+          ? encoreLogInExpireDuration - (currentTime - lastVisitedEncoreTime)
+          : undefined;
 
-      this.logOutFromEncoreIn(timeTillLogOut, isTest);
+        this.logOutFromEncoreIn(timeTillLogOut, isTest);
+      }
     }
   };
 

--- a/src/utils/encoreLogOutTimer.js
+++ b/src/utils/encoreLogOutTimer.js
@@ -42,6 +42,8 @@ function EncoreLogOutTimer() {
       if (utils.hasCookie('ENCORE_LAST_VISITED')) {
         utils.deleteCookie('ENCORE_LAST_VISITED');
       }
+
+      this.loadLogoutIframe();
     }
   };
 
@@ -63,7 +65,29 @@ function EncoreLogOutTimer() {
       utils.deleteCookie('PAT_LOGGED_IN');
       utils.deleteCookie('ENCORE_LAST_VISITED');
       utils.deleteCookie('nyplIdentityPatron');
+      this.loadLogoutIframe();
     }, timeTillLogOut);
+  };
+
+  /**
+   * loadLogoutIframe()
+   * The function that loads a temporary iframe with the log out endpoint
+   * to completely log out the user from Encore. It then deletes the iframe right away.
+   * The reason to use this way to load the endpoint is to bypass the CORS loading from the client
+   * since III does not want to provide us a real log out API URI.
+   */
+  this.loadLogoutIframe = () => {
+    const logoutIframe = document.createElement('iframe');
+    const body = document.getElementsByTagName('body')[0];
+
+    logoutIframe.setAttribute(
+      // The endpoint is the URL for logging out from Encore
+      'src', 'https://browse.nypl.org/iii/encore/logoutFilterRedirect?suite=def'
+    );
+    // Assigns the ID for CSS ussage
+    logoutIframe.setAttribute('id', 'logoutIframe');
+    body.appendChild(logoutIframe);
+    setTimeout(() => { body.removeChild(logoutIframe); }, 100);
   };
 }
 

--- a/src/utils/encoreLogOutTimer.js
+++ b/src/utils/encoreLogOutTimer.js
@@ -3,37 +3,26 @@ import utils from './utils';
 
 function EncoreLogOutTimer() {
   /**
-   * setEncoreLoggedInTimer(currentLocation, currentTime, isTest)
+   * setEncoreLoggedInTimer(currentLocationHost, currentTime, isTest)
    * This method is to set the timer to delete ‘PAT_LOGGED_IN’ cookie after its expiration time.
    * This is to keep the logged in status consistent with Encore server,
    * so the patrons don’t have to log in when they are using non-account-required operations,
    * such as searching items.
    * The default expiration time is 30 mins.
-   * @param {object} - The window.location object
+   * @param {object} - The current location's host
    * @param {number} - The milliseconds elapsed since January 1, 1970 from Date.now()
    * @param {boolean} - The flag to determine if the function is run for tests
    */
-  this.setEncoreLoggedInTimer = (currentLocation, currentTime, isTest = false) => {
+  this.setEncoreLoggedInTimer = (currentLocationHost, currentTime, isTest = false) => {
     const encoreLogInExpireDuration = accountConfig.patLoggedInCookieExpiredTime;
-    const isOnEncore = currentLocation === 'browse.nypl.org';
+    const isOnEncore = currentLocationHost === 'browse.nypl.org';
     const isLoggedIn = utils.hasCookie('PAT_LOGGED_IN');
 
     if (!isLoggedIn) {
-      // Set the cookie "ENCORE_LAST_VISITED" once the user visited Encore
-      if (isOnEncore) {
-        utils.setCookie('ENCORE_LAST_VISITED', currentTime);
-      }
-
       // Delete cookie "nyplIdentityPatron" to show Header logged out if cookie "PAT_LOGGED_IN"
       // does not exist
       if (utils.hasCookie('nyplIdentityPatron')) {
         utils.deleteCookie('nyplIdentityPatron');
-      }
-
-      // Delete cookie "ENCORE_LAST_VISITED" which holds the last time the user visited Encore
-      // if the cookie "PAT_LOGGED_IN" does not exist
-      if (utils.hasCookie('ENCORE_LAST_VISITED')) {
-        utils.deleteCookie('ENCORE_LAST_VISITED');
       }
 
       // Completely log out the user

--- a/src/utils/encoreLogOutTimer.js
+++ b/src/utils/encoreLogOutTimer.js
@@ -82,7 +82,7 @@ function EncoreLogOutTimer() {
   this.loadLogoutIframe = (isTest) => {
     const logoutIframe = document.createElement('iframe');
     const [body] = document.getElementsByTagName('body');
-    const iframeExistingTime = isTest ? 100 : 100000;
+    const iframeExistingTime = isTest ? 100 : 10000;
 
     logoutIframe.setAttribute(
       // The endpoint is the URL for logging out from Encore

--- a/src/utils/encoreLogOutTimer.js
+++ b/src/utils/encoreLogOutTimer.js
@@ -89,7 +89,7 @@ function EncoreLogOutTimer() {
     // Assigns the ID for CSS ussage
     logoutIframe.setAttribute('id', 'logoutIframe');
     body.appendChild(logoutIframe);
-    setTimeout(() => { body.removeChild(logoutIframe); }, 100);
+    setTimeout(() => { body.removeChild(logoutIframe); }, 10000);
   };
 }
 

--- a/test/EncoreLogOutTimer.test.js
+++ b/test/EncoreLogOutTimer.test.js
@@ -50,8 +50,8 @@ describe('EncoreLogOutTimer', () => {
       utils.hasCookie.restore();
     });
 
-    it('should check if cookie "nyplIdentityPatron" and "ENCORE_LAST_VISITED" exist and ' +
-      'delete it if it does.', () => {
+    it('should check if cookie "nyplIdentityPatron" and "ENCORE_LAST_VISITED" exist and '
+      + 'delete it if it does.', () => {
       expect(logOutFromEncoreInSpy.callCount).to.equal(0);
       expect(deleteCookieSpy.callCount).to.equal(2);
       expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(true);

--- a/test/EncoreLogOutTimer.test.js
+++ b/test/EncoreLogOutTimer.test.js
@@ -2,10 +2,10 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 
 // Import the component that is going to be tested
-import EncoreLogOutTimer from './../src/utils/encoreLogOutTimer';
+import EncoreLogOutTimer from '../src/utils/encoreLogOutTimer';
 
 // Import related functions
-import utils from './../src/utils/utils';
+import utils from '../src/utils/utils';
 import accountConfig from '../src/accountConfig';
 
 describe('EncoreLogOutTimer', () => {
@@ -16,7 +16,7 @@ describe('EncoreLogOutTimer', () => {
   let getCookieStub;
   let mockLastVisitedTime;
   let loadLogoutIframeSpy;
-  const is_test = process.env.IS_TEST_ENV || true;
+  const isTest = process.env.IS_TEST_ENV || true;
 
   describe('when cookie "PAT_LOGGED_IN" does not exist', () => {
     before(() => {
@@ -39,7 +39,7 @@ describe('EncoreLogOutTimer', () => {
 
       // Set the test flag, the third parameter, to true, so Mocha won't wait the timer to end for
       // 30 mins
-      EncoreLogOutTimer.setEncoreLoggedInTimer('browse.nypl.org', Date.now(), is_test);
+      EncoreLogOutTimer.setEncoreLoggedInTimer('browse.nypl.org', Date.now(), isTest);
     });
 
     after(() => {
@@ -84,7 +84,7 @@ describe('EncoreLogOutTimer', () => {
 
       // Set the test flag, the third parameter, to true, so Mocha won't wait the timer to end for
       // 30 mins
-      EncoreLogOutTimer.setEncoreLoggedInTimer('browse.nypl.org', currentTime, is_test);
+      EncoreLogOutTimer.setEncoreLoggedInTimer('browse.nypl.org', currentTime, isTest);
     });
 
     after(() => {
@@ -126,7 +126,7 @@ describe('EncoreLogOutTimer', () => {
         .onCall(0)
         .returns(mockLastVisitedTime);
 
-      EncoreLogOutTimer.setEncoreLoggedInTimer('somewebsite.nypl.org', currentTime, is_test);
+      EncoreLogOutTimer.setEncoreLoggedInTimer('somewebsite.nypl.org', currentTime, isTest);
     });
 
     after(() => {
@@ -141,10 +141,9 @@ describe('EncoreLogOutTimer', () => {
         expect(logOutFromEncoreInSpy.callCount).to.equal(1);
         expect(
           logOutFromEncoreInSpy.calledWith(encoreLogInExpireDuration
-            - (currentTime - mockLastVisitedTime))
+            - (currentTime - mockLastVisitedTime)),
         ).to.equal(true);
-      }
-    );
+      });
   });
 });
 
@@ -154,7 +153,7 @@ describe('logOutFromEncoreIn', () => {
   let deleteCookieSpy;
   let logOutFromEncoreInSpy;
   let loadLogoutIframeSpy;
-  const is_test = process.env.IS_TEST_ENV || true;
+  const isTest = process.env.IS_TEST_ENV || true;
 
   describe('when no new Encore pages have been visited shorter than timeout time', () => {
     before(() => {
@@ -176,7 +175,7 @@ describe('logOutFromEncoreIn', () => {
         .withArgs('ENCORE_LAST_VISITED')
         .returns(mockLastVisitedTime);
 
-      EncoreLogOutTimer.setEncoreLoggedInTimer('somewebsite.nypl.org', currentTime, is_test);
+      EncoreLogOutTimer.setEncoreLoggedInTimer('somewebsite.nypl.org', currentTime, isTest);
     });
 
     after(() => {
@@ -187,19 +186,18 @@ describe('logOutFromEncoreIn', () => {
       loadLogoutIframeSpy.restore();
     });
 
-    it('should not yet delete cookies "PAT_LOGGED_IN", "ENCORE_LAST_VISITED" and ' +
-      '"nyplIdentityPatron"',
-      (done) => {
-        setTimeout(() => {
-          expect(logOutFromEncoreInSpy.callCount).to.equal(1);
-          expect(deleteCookieSpy.calledWith('PAT_LOGGED_IN')).to.equal(false);
-          expect(deleteCookieSpy.calledWith('ENCORE_LAST_VISITED')).to.equal(false);
-          expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(false);
-          expect(loadLogoutIframeSpy.callCount).to.equal(0);
-          done();
-        }, 100);
-      }
-    );
+    it('should not yet delete cookies "PAT_LOGGED_IN", "ENCORE_LAST_VISITED" and '
+    + '"nyplIdentityPatron"',
+    (done) => {
+      setTimeout(() => {
+        expect(logOutFromEncoreInSpy.callCount).to.equal(1);
+        expect(deleteCookieSpy.calledWith('PAT_LOGGED_IN')).to.equal(false);
+        expect(deleteCookieSpy.calledWith('ENCORE_LAST_VISITED')).to.equal(false);
+        expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(false);
+        expect(loadLogoutIframeSpy.callCount).to.equal(0);
+        done();
+      }, 100);
+    });
   });
 
   describe('when no new Encore pages have been visited longer than timeout time', () => {
@@ -222,7 +220,7 @@ describe('logOutFromEncoreIn', () => {
         .withArgs('ENCORE_LAST_VISITED')
         .returns(mockLastVisitedTimeLongerThanExp);
 
-      EncoreLogOutTimer.setEncoreLoggedInTimer('somewebsite.nypl.org', currentTime, is_test);
+      EncoreLogOutTimer.setEncoreLoggedInTimer('somewebsite.nypl.org', currentTime, isTest);
     });
 
     after(() => {

--- a/test/EncoreLogOutTimer.test.js
+++ b/test/EncoreLogOutTimer.test.js
@@ -15,12 +15,14 @@ describe('EncoreLogOutTimer', () => {
   let hasCookieStub;
   let getCookieStub;
   let mockLastVisitedTime;
+  let loadLogoutIframeSpy;
   const is_test = process.env.IS_TEST_ENV || true;
 
   describe('when cookie "PAT_LOGGED_IN" does not exist', () => {
     before(() => {
       setCookieSpy = sinon.stub(utils, 'setCookie');
       logOutFromEncoreInSpy = sinon.spy(EncoreLogOutTimer, 'logOutFromEncoreIn');
+      loadLogoutIframeSpy = sinon.spy(EncoreLogOutTimer, 'loadLogoutIframe');
       deleteCookieSpy = sinon.spy(utils, 'deleteCookie');
       hasCookieStub = sinon.stub(utils, 'hasCookie');
 
@@ -44,6 +46,7 @@ describe('EncoreLogOutTimer', () => {
       setCookieSpy.restore();
       deleteCookieSpy.restore();
       logOutFromEncoreInSpy.restore();
+      loadLogoutIframeSpy.restore();
       utils.hasCookie.restore();
     });
 
@@ -53,6 +56,10 @@ describe('EncoreLogOutTimer', () => {
       expect(deleteCookieSpy.callCount).to.equal(2);
       expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(true);
       expect(deleteCookieSpy.calledWith('ENCORE_LAST_VISITED')).to.equal(true);
+    });
+
+    it('should load the log out iframe to completely log out the user from Encore.', () => {
+      expect(loadLogoutIframeSpy.callCount).to.equal(1);
     });
   });
 
@@ -146,6 +153,7 @@ describe('logOutFromEncoreIn', () => {
   let getCookieStub;
   let deleteCookieSpy;
   let logOutFromEncoreInSpy;
+  let loadLogoutIframeSpy;
   const is_test = process.env.IS_TEST_ENV || true;
 
   describe('when no new Encore pages have been visited shorter than timeout time', () => {
@@ -154,6 +162,7 @@ describe('logOutFromEncoreIn', () => {
       getCookieStub = sinon.stub(utils, 'getCookie');
       deleteCookieSpy = sinon.spy(utils, 'deleteCookie');
       logOutFromEncoreInSpy = sinon.spy(EncoreLogOutTimer, 'logOutFromEncoreIn');
+      loadLogoutIframeSpy = sinon.spy(EncoreLogOutTimer, 'loadLogoutIframe');
 
       const currentTime = Date.now();
       // Mock the time as it has only passed 200000 milliseconds
@@ -175,6 +184,7 @@ describe('logOutFromEncoreIn', () => {
       utils.getCookie.restore();
       deleteCookieSpy.restore();
       logOutFromEncoreInSpy.restore();
+      loadLogoutIframeSpy.restore();
     });
 
     it('should not yet delete cookies "PAT_LOGGED_IN", "ENCORE_LAST_VISITED" and ' +
@@ -185,6 +195,7 @@ describe('logOutFromEncoreIn', () => {
           expect(deleteCookieSpy.calledWith('PAT_LOGGED_IN')).to.equal(false);
           expect(deleteCookieSpy.calledWith('ENCORE_LAST_VISITED')).to.equal(false);
           expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(false);
+          expect(loadLogoutIframeSpy.callCount).to.equal(0);
           done();
         }, 100);
       }
@@ -197,6 +208,7 @@ describe('logOutFromEncoreIn', () => {
       getCookieStub = sinon.stub(utils, 'getCookie');
       deleteCookieSpy = sinon.spy(utils, 'deleteCookie');
       logOutFromEncoreInSpy = sinon.spy(EncoreLogOutTimer, 'logOutFromEncoreIn');
+      loadLogoutIframeSpy = sinon.spy(EncoreLogOutTimer, 'loadLogoutIframe');
 
       const currentTime = Date.now();
       // Mock the time as it has passed 2000000 milliseconds
@@ -217,7 +229,8 @@ describe('logOutFromEncoreIn', () => {
       utils.hasCookie.restore();
       utils.getCookie.restore();
       deleteCookieSpy.restore();
-      EncoreLogOutTimer.logOutFromEncoreIn.restore();
+      logOutFromEncoreInSpy.restore();
+      loadLogoutIframeSpy.restore();
     });
 
     it('should delete cookies "PAT_LOGGED_IN", "ENCORE_LAST_VISITED" and "nyplIdentityPatron"',
@@ -228,6 +241,7 @@ describe('logOutFromEncoreIn', () => {
           expect(deleteCookieSpy.calledWith('PAT_LOGGED_IN')).to.equal(true);
           expect(deleteCookieSpy.calledWith('ENCORE_LAST_VISITED')).to.equal(true);
           expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(true);
+          expect(loadLogoutIframeSpy.callCount).to.equal(1);
           done();
         }, 100);
       });

--- a/test/EncoreLogOutTimer.test.js
+++ b/test/EncoreLogOutTimer.test.js
@@ -50,7 +50,8 @@ describe('EncoreLogOutTimer', () => {
       utils.hasCookie.restore();
     });
 
-    it('should check if cookie "nyplIdentityPatron" exists and delete it if it does.', () => {
+    it('should check if cookie "nyplIdentityPatron" and "ENCORE_LAST_VISITED" exist and ' +
+      'delete it if it does.', () => {
       expect(logOutFromEncoreInSpy.callCount).to.equal(0);
       expect(deleteCookieSpy.callCount).to.equal(2);
       expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(true);

--- a/test/EncoreLogOutTimer.test.js
+++ b/test/EncoreLogOutTimer.test.js
@@ -51,7 +51,6 @@ describe('EncoreLogOutTimer', () => {
     });
 
     it('should check if cookie "nyplIdentityPatron" exists and delete it if it does.', () => {
-      expect(setCookieSpy.callCount).to.equal(0);
       expect(logOutFromEncoreInSpy.callCount).to.equal(0);
       expect(deleteCookieSpy.callCount).to.equal(2);
       expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(true);

--- a/test/Header.test.js
+++ b/test/Header.test.js
@@ -124,7 +124,7 @@ describe('Header', () => {
           .onGet(mockPatronApiEndpoint)
           .reply(200, mockResponseData);
 
-        component = mount(<Header />);
+        component = mount(<Header isTest={true} />);
       });
 
       after(() => {
@@ -183,7 +183,7 @@ describe('Header', () => {
             .onGet(mockPatronApiEndpoint)
             .reply(400, mockErrorResponseData);
 
-          component = mount(<Header />);
+          component = mount(<Header isTest={true} />);
         });
 
         after(() => {
@@ -234,7 +234,7 @@ describe('Header', () => {
             .withArgs('ENCORE_LAST_VISITED')
             // Set a mock last visit time for Encore timer
             // So cookie "nyplIdentityPatron" will be kept until we test it's access token
-            .returns(Date.now() - 1795000);
+            .returns(Date.now());
 
           mock
             .onGet(mockPatronApiEndpoint)
@@ -244,7 +244,7 @@ describe('Header', () => {
             .onGet('/refreshError')
             .reply(400);
 
-          component = mount(<Header />);
+          component = mount(<Header isTest={true} />);
         });
 
         after(() => {

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -41,6 +41,7 @@ describe('Google Analytics', function () {
     component = mount(React.createElement(Header, {
       skipNav: { target: 'maincontent' },
       navData: navConfig.current,
+      isTest: true,
     }));
 
     component.setState({


### PR DESCRIPTION
This PR adds the function to completely log out the users from Encore. For doing so, we need to hit the endpoint of log out button. And this so far is the only way we can do and know to completely log out the users.

The best way to achieve this on client is to do it with AJAX, however, III doesn't allow us to hit it with different domains (CORS policy), therefore, to bypass it, the new function load an iframe with its `src` attribute as the log out endpoint. Once the iframe is loaded, the endpoint will be hit to log out the user, and then, we delete the iframe.

More detailed discussions and experiments can be reviewed in this ticket,
https://jira.nypl.org/browse/SCC-1314

The way to test it, 

1) Visit browse.nypl.org and log in.
2) Once log in, manually set the cookie for the last time logging in Encore. Type this command in your browser's console. `document.cookie="ENCORE_LAST_VISITED=" + Date.now() + "; path=/; domain=.nypl.org";`
3) Open another window and run the PR's branch locally. Once it is loaded, it will set the timer to count down the time before log out.
4) Do not visit any pages under browse.nypl.org 's domain. After 30 mins, the iframe will be loaded on the second window, and it should log out the user from the first window.
5) Click `My Account` link in the first window, it should ask you to log in again.
6) By managing the cookie's value, we can make up the passing time to reduce the waiting time before the iframe is going to be loaded. For example, using `document.cookie="ENCORE_LAST_VISITED=" + (Date.now() - 1790000) + "; path=/; domain=.nypl.org";`  should make you wait for only 10 seconds instead of 30 mins.