### PR TITLE
Fix logout after login redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ### CHANGE LOG
 
 ========
+### v2.5.8
+> Fix bugs introduced in 2.5.6:
+  - Logging in with a non-catalog redirect_uri causes immediate logout
+  - Logout iframe is loaded recklessly for users that are not logged in
+
 ### v2.5.7
 > Update package-lock.json file that prevent newer version of packages to load and locally build the app properly. Updated documented git workflow for contributing.
 

--- a/dist/utils/encoreCatalogLogOutTimer.js
+++ b/dist/utils/encoreCatalogLogOutTimer.js
@@ -57,12 +57,14 @@ function EncoreCatalogLogOutTimer() {
       if (_utils2.default.hasCookie('VALID_DOMAIN_LAST_VISITED')) {
         _utils2.default.deleteCookie('VALID_DOMAIN_LAST_VISITED');
       }
-
-      // Completely log out the user
-      _this.loadLogoutIframe(isTest);
     } else {
-      if (isOnValidDomain) {
-        // Set the cookie "VALID_DOMAIN_LAST_VISITED" once the user visited Encore or Catalog
+      // Update VALID_DOMAIN_LAST_VISITED in two scenarios:
+      //  1. Patron is on a Sierra hosted page, so actively refreshing their
+      //     session
+      //  2. The VALID_DOMAIN_LAST_VISITED cookie doesn't exist, which will
+      //     only happen if the patron logged in through a redirect, without
+      //     running JS on a "valid domain"
+      if (isOnValidDomain || !_utils2.default.hasCookie('VALID_DOMAIN_LAST_VISITED')) {
         _utils2.default.setCookie('VALID_DOMAIN_LAST_VISITED', currentTime);
         _this.logOutFromEncoreAndCatalogIn(encoreLogInExpireDuration, isTest);
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "NYPL Header as a React component.",
   "main": "dist/components/Header/Header.js",
   "scripts": {

--- a/src/utils/encoreCatalogLogOutTimer.js
+++ b/src/utils/encoreCatalogLogOutTimer.js
@@ -38,9 +38,6 @@ function EncoreCatalogLogOutTimer() {
       if (utils.hasCookie('VALID_DOMAIN_LAST_VISITED')) {
         utils.deleteCookie('VALID_DOMAIN_LAST_VISITED');
       }
-
-      // Completely log out the user
-      this.loadLogoutIframe(isTest);
     } else {
       // Update VALID_DOMAIN_LAST_VISITED in two scenarios:
       //  1. Patron is on a Sierra hosted page, so actively refreshing their

--- a/src/utils/encoreCatalogLogOutTimer.js
+++ b/src/utils/encoreCatalogLogOutTimer.js
@@ -42,8 +42,13 @@ function EncoreCatalogLogOutTimer() {
       // Completely log out the user
       this.loadLogoutIframe(isTest);
     } else {
-      if (isOnValidDomain) {
-        // Set the cookie "VALID_DOMAIN_LAST_VISITED" once the user visited Encore or Catalog
+      // Update VALID_DOMAIN_LAST_VISITED in two scenarios:
+      //  1. Patron is on a Sierra hosted page, so actively refreshing their
+      //     session
+      //  2. The VALID_DOMAIN_LAST_VISITED cookie doesn't exist, which will
+      //     only happen if the patron logged in through a redirect, without
+      //     running JS on a "valid domain"
+      if (isOnValidDomain || !utils.hasCookie('VALID_DOMAIN_LAST_VISITED')) {
         utils.setCookie('VALID_DOMAIN_LAST_VISITED', currentTime);
         this.logOutFromEncoreAndCatalogIn(encoreLogInExpireDuration, isTest);
       } else {

--- a/test/EncoreCatalogLogOutTimer.test.js
+++ b/test/EncoreCatalogLogOutTimer.test.js
@@ -240,6 +240,7 @@ describe('EncoreLogOutTimer', () => {
           // Expect logout timer called with full time:
           logOutFromEncoreAndCatalogInSpy.calledWith(accountConfig.patLoggedInCookieExpiredTime)
         ).to.equal(true);
+        expect(setCookieSpy.calledWith('VALID_DOMAIN_LAST_VISITED', currentTime)).to.equal(true);
       });
   });
 

--- a/test/EncoreCatalogLogOutTimer.test.js
+++ b/test/EncoreCatalogLogOutTimer.test.js
@@ -11,6 +11,7 @@ import accountConfig from '../src/accountConfig';
 // Matcher to fuzzily match a Unix ms value to within a few seconds:
 let matchWithinACoupleSecondsOf = (expectedTime, threshold = 2000) => {
   return sinon.match(function (actualTime) {
+    console.log(`Fuzzy matching a timestamp. Actual: ${actualTime}, Expected: ${expectedTime}, Difference: ${Math.abs(expectedTime - actualTime)}`)
     return Math.abs(expectedTime - actualTime) <= threshold
   })
 }
@@ -245,7 +246,7 @@ describe('EncoreLogOutTimer', () => {
         ).to.equal(true);
 
         // Verify cookie created with a value that's extremely recent
-        expect(setCookieSpy.calledWith('VALID_DOMAIN_LAST_VISITED', matchWithinACoupleSecondsOf(Date.now()))).to.equal(true);
+        expect(setCookieSpy.calledWith('VALID_DOMAIN_LAST_VISITED', matchWithinACoupleSecondsOf(Date.now(), 3000))).to.equal(true);
       });
   });
 

--- a/test/EncoreCatalogLogOutTimer.test.js
+++ b/test/EncoreCatalogLogOutTimer.test.js
@@ -25,7 +25,6 @@ describe('EncoreLogOutTimer', () => {
         EncoreCatalogLogOutTimer,
         'logOutFromEncoreAndCatalogIn',
       );
-      loadLogoutIframeSpy = sinon.spy(EncoreCatalogLogOutTimer, 'loadLogoutIframe');
       deleteCookieSpy = sinon.spy(utils, 'deleteCookie');
       hasCookieStub = sinon.stub(utils, 'hasCookie');
 
@@ -49,7 +48,6 @@ describe('EncoreLogOutTimer', () => {
       setCookieSpy.restore();
       deleteCookieSpy.restore();
       logOutFromEncoreAndCatalogInSpy.restore();
-      loadLogoutIframeSpy.restore();
       utils.hasCookie.restore();
     });
 
@@ -59,10 +57,6 @@ describe('EncoreLogOutTimer', () => {
       expect(deleteCookieSpy.callCount).to.equal(2);
       expect(deleteCookieSpy.calledWith('nyplIdentityPatron')).to.equal(true);
       expect(deleteCookieSpy.calledWith('VALID_DOMAIN_LAST_VISITED')).to.equal(true);
-    });
-
-    it('should load the log out iframe to completely log out the user from Encore.', () => {
-      expect(loadLogoutIframeSpy.callCount).to.equal(1);
     });
   });
 

--- a/test/EncoreCatalogLogOutTimer.test.js
+++ b/test/EncoreCatalogLogOutTimer.test.js
@@ -8,14 +8,6 @@ import EncoreCatalogLogOutTimer from '../src/utils/encoreCatalogLogOutTimer';
 import utils from '../src/utils/utils';
 import accountConfig from '../src/accountConfig';
 
-// Matcher to fuzzily match a Unix ms value to within a few seconds:
-let matchWithinACoupleSecondsOf = (expectedTime, threshold = 2000) => {
-  return sinon.match(function (actualTime) {
-    console.log(`Fuzzy matching a timestamp. Actual: ${actualTime}, Expected: ${expectedTime}, Difference: ${Math.abs(expectedTime - actualTime)}`)
-    return Math.abs(expectedTime - actualTime) <= threshold
-  })
-}
-
 describe('EncoreLogOutTimer', () => {
   let deleteCookieSpy;
   let setCookieSpy;
@@ -246,7 +238,7 @@ describe('EncoreLogOutTimer', () => {
         ).to.equal(true);
 
         // Verify cookie created with a value that's extremely recent
-        expect(setCookieSpy.calledWith('VALID_DOMAIN_LAST_VISITED', matchWithinACoupleSecondsOf(Date.now(), 3000))).to.equal(true);
+        expect(setCookieSpy.calledWith('VALID_DOMAIN_LAST_VISITED', currentTime)).to.equal(true);
       });
   });
 


### PR DESCRIPTION
Fixes two things:
1. **Failed login after redirect**: a bug where - after logging in through a redirect, the receiving
page logs the user out because `VALID_DOMAIN_LAST_VISITED` wasn't set on
a "valid domain".
2. **Fix aggressive logouts**: do not load Encore logout in iframe for users that are not logged in. It is almost entirely unnecessary and likely a strain on Sierra as it runs the logout logic for all unauthenticated page accesses.

## 1. Failed login after redirect

Background: The header update drops a `VALID_DOMAIN_LAST_VISITED` cookie when the patron browses on a catalog/encore page and appears to be logged in (indicated by presence of `PAT_LOGGED_IN`). This works fine when one logs in via the login buttons in the header because those links redirect to a Sierra hosted page where the header js will execute and drop the `VALID_DOMAIN_LAST_VISITED` cookie.

The trouble ([originally described in a hotfix applied to SCC](https://github.com/NYPL-discovery/discovery-front-end/pull/1020)) arises in the following:

 - user is not logged in
 - user clicks "Request" on a SCC item
 - controller redirects user to login form
 - upon successful login, the login endpoint issues a 302 redirect back to SCC (skipping any opportunity to run the updated header js to drop the new VALID_DOMAIN_LAST_VISITED cookie)
 - upon arriving back at SCC, because there is no `VALID_DOMAIN_LAST_VISITED` cookie, the header js logs the user out.

Our header-js drops a cooke when running on a Sierra-hosted page. The same header-js anticipates that cookie on non-Sierra-hosted pages. The root of the issue is that we assume the header-js will always run on the Sierra-hosted page first. We can address this by distributing responsibility somewhat for dropping that cookie. After all, it's not important that a Sierra-hosted page actually write the cookie; It's just important that it be written as soon as possible after the patron logs in. Thus, this fix adds a clause to allow the `VALID_DOMAIN_LAST_VISITED` cookie to be written either 1) when visiting a Sierra-hosted page, or 2) on any other page where the user appears to be logged in but the cookie has not yet been dropped. GIven that the same header-js is running across all NYPL properties, I argue that it's safe to assume that any patron that 1) is logged in, and 2) does not have a `VALID_DOMAIN_LAST_VISITED` cookie must have logged in extremely recently (i.e. via a login redirect)

## 2 . Fix aggressive logouts:

Currently, when no `PAT_LOGGED_IN` cookie is detected, the user is assumed to be logged out. In that case, the header-js deletes `nyplIdentityPatron` (which is good as it ensures the authentication state of the header matches Sierra pages), and `VALID_DOMAIN_LAST_VISITED` (which is unnecessary, but fine). It also immediately loads an iframe with the Sierra logout page. This was done to completely clear *all* trace of the Sierra session. For the majority of cases where an unauthenticated patron visits a page, it seems a waste t load the Sierra logout page. There may be some cases where loading the logout page is necessary to address the login-to-search bug that the recent header update sought to fix. I'd argue that bug is largely addressed by the *other place* where we load the iframe - namely: when `VALID_DOMAIN_LAST_VISITED` indicates the Sierra session has gone stale. Provided that cookie is created and not solely edited/deleted by the patron, the mechanism should ensure the logout page is loaded by iframe exactly once when the `VALID_DOMAIN_LAST_VISITED` indicates it is time.

## On pragmatism/idealism

There are likely more elegant fixes. This PR intentionally changes as few things about the original mechanism as possible to ease review. If that was not a concern, I would be interested in changing a few other things, e.g.:
 - `VALID_DOMAIN_LAST_VISITED` is not the best name after this change. It might better be called `SIERRA_SESSION_REFRESHED` to indicate it stores the last time the visitor refreshed their Sierra session id
 - I'm not sure why `setEncoreLoggedInTimer` takes a `currentTime` argument when it should itself have decent sense of the current system time.