### PR TITLE
Deprecate JS Styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### CHANGE LOG
 
 ========
+### v2.7.0
+> Deprecates some JS-in-CSS styling for buttons. Centers the yellow alert bar on desktop breakpoints.
+
 ### v2.6.0
 > Remove Kievit font
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/dgx-header-component",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "NYPL Header as a React component.",
   "main": "dist/components/Header/Header.js",
   "scripts": {

--- a/src/components/DonateButton/DonateButton.js
+++ b/src/components/DonateButton/DonateButton.js
@@ -3,18 +3,12 @@ import PropTypes from 'prop-types';
 import { extend as _extend } from 'underscore';
 import utils from '../../utils/utils.js';
 
-const defaultStyles = {
-  backgroundColor: '#E32B31',
-  color: '#FFFFFF',
-};
-
 const DonateButton = ({ id, className, target, label, gaLabel, style }) => (
   <a
     id={id}
     className={className}
     href={target}
     onClick={() => utils.trackHeader('Donate', gaLabel)}
-    style={_extend(style, defaultStyles)}
   >
     {label}
   </a>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -38,39 +38,6 @@ const styles = {
     textTransform: 'uppercase',
     display: 'block',
   },
-  locationsTopLink: {
-    display: 'inline-block',
-    color: '#000',
-    backgroundColor: '#FFF',
-    padding: '12px',
-    verticalAlign: 'baseline',
-  },
-  libraryCardButton: {
-    display: 'inline-block',
-    color: '#000',
-    backgroundColor: '#FFF',
-    padding: '12px',
-    verticalAlign: 'baseline',
-  },
-  subscribeButton: {
-    display: 'inline-block',
-    margin: '0px 10px 0px 0px',
-    verticalAlign: 'baseline',
-  },
-  donateButton: {
-    display: 'inline-block',
-    padding: '10px 18px',
-    margin: '0 5px 0 0',
-    lineHeight: 'normal',
-    verticalAlign: 'baseline',
-  },
-  shopLink: {
-    color: '#000',
-    backgroundColor: '#FFF',
-    padding: '10px 15px',
-    margin: '0 0 0 5px',
-    verticalAlign: 'baseline',
-  },
   mobileMyNypl: {
     position: 'absolute',
     zIndex: 1000,
@@ -238,8 +205,8 @@ class Header extends React.Component {
               style={styles.topButtons}
               aria-label="Header top links"
             >
-              <ul>
-                <li>
+              <ul className="top-links">
+                <li className="top-links__item">
                   <MyNyplButton
                     refId="desktopLogin"
                     isLoggedIn={isLoggedIn}
@@ -248,7 +215,7 @@ class Header extends React.Component {
                     gaAction={isLoggedIn ? 'My Account' : 'Log In'}
                   />
                 </li>
-                <li>
+                <li className="top-links__item">
                   <SimpleLink
                     label="Locations"
                     target={
@@ -259,10 +226,9 @@ class Header extends React.Component {
                     id="locationsTopLink"
                     gaAction="Locations"
                     gaLabel="Header Top Links"
-                    style={styles.locationsTopLink}
                   />
                 </li>
-                <li>
+                <li className="top-links__item">
                   <SimpleLink
                     label="Get a Library Card"
                     target={
@@ -276,22 +242,21 @@ class Header extends React.Component {
                     style={styles.libraryCardButton}
                   />
                 </li>
-                <li>
+                <li className="top-links__item">
                   <SubscribeButton
                     label="Get Email Updates"
                     lang={this.props.lang}
-                    style={styles.subscribeButton}
                   />
                 </li>
-                <li>
+                <li className="top-links__item">
                   <DonateButton
                     id="donateButton"
                     lang={this.props.lang}
-                    style={styles.donateButton}
                     gaLabel="Header Top Links"
+                    className="donateButton"
                   />
                 </li>
-                <li>
+                <li className="top-links__item">
                   <SimpleLink
                     label="Shop"
                     target={'http://shop.nypl.org/?utm_campaign=NYPLHeaderButton&utm_' +
@@ -300,7 +265,6 @@ class Header extends React.Component {
                     id="shopTopLink"
                     gaAction="Shop"
                     gaLabel="Header Top Links"
-                    style={styles.shopLink}
                   />
                 </li>
               </ul>

--- a/src/components/MyNyplButton/MyNyplButton.js
+++ b/src/components/MyNyplButton/MyNyplButton.js
@@ -15,7 +15,6 @@ import appConfig from '../../appConfig.js';
 
 const styles = {
   base: {
-    margin: '0px 10px 0px 0px',
     position: 'relative',
     display: 'inline-block',
     verticalAlign: 'baseline',
@@ -24,8 +23,7 @@ const styles = {
   MyNyplButton: {
     display: 'inline',
     border: 'none',
-    padding: '11px 10px 11px 12px',
-    textTransform: 'uppercase',
+    padding: '11px 0 11px 12px',
     lineHeight: 'normal',
     verticalAlign: 'baseline',
   },

--- a/src/components/NavMenuMobileButtons/NavMenuMobileButtons.js
+++ b/src/components/NavMenuMobileButtons/NavMenuMobileButtons.js
@@ -70,16 +70,6 @@ const styles = {
     color: '#959595',
     backgroundColor: '#2B2B2B',
   },
-  donateLink: {
-    display: 'block',
-    fontSize: '16px',
-    lineHeight: 'normal',
-    margin: '0 0 0 3px',
-    padding: '1.75em 0',
-    textAlign: 'center',
-    textTransform: 'uppercase',
-    width: '98.5%',
-  },
   shopLink: {
     backgroundColor: '#2B2B2B',
     borderTop: '2px solid #363636',
@@ -90,7 +80,6 @@ const styles = {
     padding: 0,
     textAlign: 'center',
     textDecoration: 'none',
-    
   },
 };
 
@@ -169,7 +158,6 @@ const NavMenuMobileButtons = ({
       <DonateButton
         id="mobileNav-donateButton"
         className="donateLink"
-        style={styles.donateLink}
         gaLabel="Mobile Buttons Donate"
       />
     </div>

--- a/src/components/SubscribeButton/SubscribeButton.js
+++ b/src/components/SubscribeButton/SubscribeButton.js
@@ -19,22 +19,11 @@ const styles = {
   },
   subscribeButton: {
     display: 'inline',
-    padding: '11px 10px 11px 12px',
     verticalAlign: 'baseline',
   },
   subscribeLabel: {
     display: 'inline',
     verticalAlign: 'baseline',
-  },
-  EmailSubscribeForm: {
-    position: 'absolute',
-    zIndex: 1000,
-    right: '0',
-    width: '250px',
-    minHeight: '210px',
-    backgroundColor: '#1B7FA7',
-    padding: '25px 30px',
-    marginTop: '10px',
   },
   hide: {
     display: 'none',
@@ -167,7 +156,6 @@ class SubscribeButton extends React.Component {
     return this.state.visible ? (
       <div
         className="emailSubscription-wrapper active animatedFast fadeIn"
-        style={styles.EmailSubscribeForm}
       >
         <EmailSubscription
           listId="1061"

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -3,39 +3,8 @@
  * - Library Card
  * - Donate
 */
-&-buttons {
-  ul {
-    margin: 0;
-    list-style-type: none;
 
-    li {
-      display: inline-block;
-      margin-right: 0.18em;
-    }
-  }
-
-  // First instance top-level <a> tags
-  li > a,
-  & > a {
-    @include System-Bold;
-    font-size: 13px;
-    letter-spacing: .04em;
-    margin: 0 10px 0 0;
-
-    &:visited {
-      color: #000;
-    }
-
-    &:last-child {
-      margin: 0;
-    }
-
-    &:focus {
-      @include basic-focus;
-      padding: 12px;
-    }
-  }
-
+.header-buttons {
   @include min-screen(769px) {
     right: 0px;
   }
@@ -44,45 +13,66 @@
     right: 20px;
   }
 
-  .subscribeButton,
-  .myNyplButton {
-    @include System-Bold;
-    font-size: 13px;
-    color: #000;
-    background-color: #FFF;
-    letter-spacing: .04em;
+  .top-links {
+    margin: 0;
+    list-style-type: none;
+    text-transform: uppercase;
 
-    &.active {
-      @include transition(background-color .2s linear 0s, color .2s linear 0s);
-      background-color: #135772;
-      color: #FFF;
+    &__item,
+    .subscribeButton,
+    .shopTopLink,
+    .libraryCardButton,
+    .locationsTopLink {
+      @include System-Bold;
+
+      display: inline-block;
+      color: black;
+      background-color: #FFF;
+      font-size: 13px;
+      letter-spacing: .04em;
+      margin-right: 2em;
 
       &:visited {
-        color: #FFF;
+        color: #000;
       }
-    }
 
-    &:focus {
-      @include basic-focus;
-    }
+      &:last-child {
+        margin: 0;
+      }
 
-    &:visited {
-      color: #000;
-    }
-
-    .icon {
-      @include opacity(0.8);
+      &:focus {
+        @include basic-focus;
+        padding: 12px;
+      }
     }
   }
 
-  .donateButton {
+  // .donateLink is for mobile
+  .donateButton,
+  .donateLink {
     @include border-radius(4px);
+
+    background-color: #e32b31;
+    color: white;
+    display: inline-block;
+    line-height: normal;
+    padding: 10px 18px;
+    vertical-align: baseline;
   }
 
   .shopTopLink {
-    display: none;
+    display: none !important;
+
     @include min-screen(860px) {
-      display: inline-block;
+      display: inline-block !important;
+    }
+
+    & .top-links__link {
+      display: none !important;
+
+      @include min-screen(860px) {
+        display: inline-block !important;
+      }
     }
   }
 
@@ -96,4 +86,18 @@
     -webkit-background-clip:padding-box; /* IOS fix */
     background-clip:padding-box; /* IOS fix */
   }
+}
+
+// .donateLink is for mobile
+.donateLink {
+  background-color: #e32b31;
+  color: white;
+  display: block;
+  font-size: 16px;
+  line-height: normal;
+  margin: 0 0 0 3px;
+  padding: 1.75em 0;
+  text-align: center;
+  text-transform: uppercase;
+  width: 98.5%;
 }

--- a/src/styles/components/_emailSubscription.scss
+++ b/src/styles/components/_emailSubscription.scss
@@ -79,7 +79,6 @@
 
     &-followUs {
       color: #fff;
-      text-transform: uppercase;
       margin-top: 40px;
       font-size: 14px;
     }

--- a/src/styles/components/_globalAlerts.scss
+++ b/src/styles/components/_globalAlerts.scss
@@ -19,10 +19,6 @@
       margin-right: 20px;
     }
 
-    @include min-screen(1025px) {
-      margin-left: 138px;
-    }
-
     &-item {
       font-size: 16px;
       margin: .5em 0;

--- a/src/styles/components/_myNypl.scss
+++ b/src/styles/components/_myNypl.scss
@@ -4,7 +4,6 @@
   font-size: 13px;
   color: #000;
   display: block;
-  letter-spacing: .04em;
   background-color: #FFF;
 
   &.loggedIn {


### PR DESCRIPTION
A number of our styles are being shared across our JavaScript files as CSS-in-JS and our in SCSS files. This means:

- You can't grep for class names you find in the markup
- It's challenging to understand where you should go to make a visual change

This PR moves a some styles from CSS-in-JS into SCSS files and bundles shared CSS where I could make that happen.

## Steps to Review:
- [ ] Run the header with `npm start` in one tab
- [ ] Open nypl.org in another
- [ ] Compare both across desktop, tablet, and mobile, and ensure there aren't any major visual changes
- [ ] On mobile, open sub-navgations: Search, Log In, and ensure everything looks the same