### PR TITLE
Centers alerts in banner

### DIFF
--- a/src/styles/components/_globalAlerts.scss
+++ b/src/styles/components/_globalAlerts.scss
@@ -19,10 +19,6 @@
       margin-right: 20px;
     }
 
-    @include min-screen(1025px) {
-      margin-left: 138px;
-    }
-
     &-item {
       font-size: 16px;
       margin: .5em 0;


### PR DESCRIPTION
Fixes an issue a left-margin was applied at the `desktop` breakpoint, causing the alert to become uncentered.

Before: 
![Screen Shot 2020-05-06 at 3 38 43 PM](https://user-images.githubusercontent.com/1720093/81220763-d8594800-8faf-11ea-99eb-4f4962da685d.png)

After:
![Screen Shot 2020-05-06 at 3 38 55 PM](https://user-images.githubusercontent.com/1720093/81220785-df805600-8faf-11ea-9ee2-03ffbb61a58a.png)
