### PR TITLE
TGR-84: Adding deprecated note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 As of September 2024, this repo and the [npm package](https://www.npmjs.com/package/@nypl/dgx-header-component), are deprecated. See the instructions in the [`nypl-header-app`](https://github.com/NYPL/nypl-header-app) repo for using the new NYPL Header and Footer.
 
-Please contact the NYPL Design System team or Remediation Team for more information.
-
 ---
 
 # NYPL Header React NPM Component

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Deprecated
+
+As of September 2024, this repo and the [npm package](https://www.npmjs.com/package/@nypl/dgx-header-component), are deprecated. See the instructions in the [`nypl-header-app`](https://github.com/NYPL/nypl-header-app) repo for using the new NYPL Header and Footer.
+
+Please contact the NYPL Design System team or Remediation Team for more information.
+
+---
+
 # NYPL Header React NPM Component
 
 [![GitHub version](https://badge.fury.io/gh/nypl%2Fdgx-header-component.svg)](https://badge.fury.io/gh/nypl%2Fdgx-header-component)


### PR DESCRIPTION
Resolves [TGR-84](https://newyorkpubliclibrary.atlassian.net/browse/TGR-84).

This adds a deprecated note to the repo since this codebase and npm package should no longer be supported. Additionally, after this is merged in, the following will be done:

- this repo will be archived
- the npm package will be marked as deprecated

The npm package is imported into various NYPL repos https://github.com/search?q=org%3ANYPL+%40nypl%2Fdgx-header-component&type=code&p=1 but these projects are either deprecated or not in use.

[TGR-84]: https://newyorkpubliclibrary.atlassian.net/browse/TGR-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ